### PR TITLE
update action should include referencedDocument

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function mongooseLogsPlugin(schema, options) {
     schema.add({
         modifiedBy: {}
     });
-    
+
     // create action logs
     schema.post('save', function(doc, next) {
         var refrenceDocument = Object.assign({}, this._doc);
@@ -24,7 +24,7 @@ function mongooseLogsPlugin(schema, options) {
             return next();
         });
     });
-// update action logs
+    // update action logs
     schema.post('update', function(doc, next) {
         var activity = {
             collectionType: options.schemaName,
@@ -34,7 +34,7 @@ function mongooseLogsPlugin(schema, options) {
         if (this._update.$set && this._update.$set.modifiedBy) {
             var refrenceDocument = Object.assign({}, this._update.$set);
             delete refrenceDocument.modifiedBy;
-
+            activity.referenceDocument = refrenceDocument;
             activity.loggedBy = this._update.$set.modifiedBy;
         } else if (this._update.$pushALogl) {
             activity.referenceDocument = this._update.$pushALogl;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function mongooseLogsPlugin(schema, options) {
             return next();
         });
     });
+
     // update action logs
     schema.post('update', function(doc, next) {
         var activity = {
@@ -46,7 +47,6 @@ function mongooseLogsPlugin(schema, options) {
         });
     });
 
-
     schema.post('findOneAndUpdate', function(doc, next) {
         var refrenceDocument = Object.assign({}, doc);
         delete refrenceDocument.modifiedBy;
@@ -62,11 +62,12 @@ function mongooseLogsPlugin(schema, options) {
             return next();
         });
     });
- // create logs for delete action
+
+    // create logs for delete action
     schema.post('findOneAndRemove', function(doc, next) {
         var activity = {
             collectionType: options.schemaName,
-            referenceDocument: refrenceDocument,
+            referenceDocument: doc,
             action: options.deleteAction || 'deleted',
             loggedBy: this.modifiedBy,
             createdAt: Date.now()
@@ -77,11 +78,10 @@ function mongooseLogsPlugin(schema, options) {
         });
     });
 
-
     schema.post('remove', function(doc, next) {
         var activity = {
             collectionType: options.schemaName,
-            referenceDocument: refrenceDocument,
+            referenceDocument: doc,
             action: options.deleteAction || 'deleted',
             loggedBy: this.modifiedBy,
             createdAt: Date.now()


### PR DESCRIPTION
Looks like there is a bug where the update action is not including the referencedDocument. My change is really just adding one line (if you ignore space differences):
   activity.referenceDocument = refrenceDocument;